### PR TITLE
Use console.log and console.error

### DIFF
--- a/compilers/javascript/src/main/java/org/thingml/compilers/javascript/node/NodeJSThingActionCompiler.java
+++ b/compilers/javascript/src/main/java/org/thingml/compilers/javascript/node/NodeJSThingActionCompiler.java
@@ -27,25 +27,4 @@ import org.thingml.xtext.thingML.PrintAction;
  */
 public class NodeJSThingActionCompiler extends JSThingActionCompiler {
 
-    @Override
-    public void generate(ErrorAction action, StringBuilder builder, Context ctx) {
-    	for (Expression msg : action.getMsg()) {
-		    builder.append("process.stderr.write(''+");
-		    generate(msg, builder, ctx);
-		    builder.append(");\n");
-    	}
-    	if (action.isLine())
-    		builder.append("process.stderr.write('\\n');\n");
-    }
-
-    @Override
-    public void generate(PrintAction action, StringBuilder builder, Context ctx) {
-    	for (Expression msg : action.getMsg()) {
-	        builder.append("process.stdout.write(''+");
-	        generate(msg, builder, ctx);
-	        builder.append(");\n");
-    	}
-    	if (action.isLine())
-    		builder.append("process.stdout.write('\\n');\n");
-    }
 }


### PR DESCRIPTION
[I read the `console.log` NodeJS source code](https://github.com/nodejs/node/blob/af6d26281f734dbbf1bf497103d1cb4b85a52b2e/lib/console.js#L204), and I see no good reason to prefer `process.stdout.write` over a beautiful `console.log`.

The `console.log` is more standard and the changes reduces the number of lines of code.