### PR TITLE
Support for the nodejs_package annotation

### DIFF
--- a/compilers/javascript/src/main/java/org/thingml/compilers/javascript/node/NodeJSCfgBuildCompiler.java
+++ b/compilers/javascript/src/main/java/org/thingml/compilers/javascript/node/NodeJSCfgBuildCompiler.java
@@ -32,11 +32,24 @@ import com.eclipsesource.json.WriterConfig;
 public class NodeJSCfgBuildCompiler extends JSCfgBuildCompiler {
 	@Override
 	public void generateBuildScript(Configuration cfg, Context ctx) {
-		String json = "";
-		for (String line : readResource("lib/package.json"))
-			json += line.replace("<NAME>", cfg.getName());
 		
+		String json = String.join("", readResource("lib/package.json"));
 		JsonObject pkg = Json.parse(json).asObject();
+		
+		String nameKebabCase = cfg.getName().replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase();
+		pkg.set("name", nameKebabCase);
+		
+		pkg.set("description", AnnotatedElementHelper.annotationOrElse(
+				cfg, "nodejs_package_description", nameKebabCase +" configuration generated from ThingML"));
+		
+		pkg.set("version", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_version", "1.0.0"));
+		pkg.set("license", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_license", "Apache-2.0"));
+		pkg.set("repository", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_repository", ""));
+		
+		JsonObject author = pkg.get("author").asObject();
+		author.set("name", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_author_name", ""));
+		author.set("email", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_author_email", ""));
+		
 		JsonValue deps = pkg.get("dependencies");
 		
 		if (AnnotatedElementHelper.hasAnnotation(cfg, "arguments")) {

--- a/compilers/javascript/src/main/resources/javascript/lib/package.json
+++ b/compilers/javascript/src/main/resources/javascript/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "<NAME>",
-  "version": "1.0.0",
-  "description": "<NAME> configuration generated from ThingML",
+  "version": "<VERSION>",
+  "description": "<DESCRIPTION>",
   "main": "main.js",
   "private": true,
   "dependencies": {
@@ -11,12 +11,12 @@
   },
   "scripts": {
   },
-  "repository": "",
+  "repository": "<REPOSITORY>",
   "author": {
-    "name": "John Doe",
-    "email": "John@Doe.com"
+    "name": "<AUTHOR_NAME>",
+    "email": "<AUTHOR_EMAIL>"
   },
-  "license": "Apache-2.0",
+  "license": "<LICENSE>",
   "eslintConfig": {
     "env": {
       "node": true
@@ -29,7 +29,6 @@
     },
     "rules": {
       "no-console": 0,
-      "no-unused-vars": ["error", {"args": "none" }],
       "no-mixed-spaces-and-tabs": 0,
       "no-unreachable": 0,
       "no-extra-semi": 0,


### PR DESCRIPTION
## Summary of the change

The `main.js` generated file is modified to allow the initialisation of the thingmodel in an exported function. The most visible changes are the `builder.append` converted to `main.append`.

Then, the terminate code is put in a `function terminate()` so it can be exported or called in the `SIGINT` handler.

The `SIGINT` handler is modified to check whether it can run (it can't on web browsers with browersify) and it is present only when the `nodejs_package` annotation is not present.

Finally, if the configuration contains the `nodejs_package` flag/annotation, an object is returned with an object of instances and the terminate function.

This should work okay.