### PR TITLE
Improve nodejs package generation

### DIFF
--- a/compilers/javascript/src/main/java/org/thingml/compilers/javascript/node/NodeJSCfgBuildCompiler.java
+++ b/compilers/javascript/src/main/java/org/thingml/compilers/javascript/node/NodeJSCfgBuildCompiler.java
@@ -33,8 +33,9 @@ public class NodeJSCfgBuildCompiler extends JSCfgBuildCompiler {
 	@Override
 	public void generateBuildScript(Configuration cfg, Context ctx) {
 		String json = "";
+		String nameKebabCase = cfg.getName().replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase();
 		for (String line : readResource("lib/package.json"))
-			json += line.replace("<NAME>", cfg.getName());
+			json += line.replace("<NAME>", nameKebabCase);
 		
 		JsonObject pkg = Json.parse(json).asObject();
 		JsonValue deps = pkg.get("dependencies");

--- a/compilers/javascript/src/main/java/org/thingml/compilers/javascript/node/NodeJSCfgBuildCompiler.java
+++ b/compilers/javascript/src/main/java/org/thingml/compilers/javascript/node/NodeJSCfgBuildCompiler.java
@@ -32,12 +32,24 @@ import com.eclipsesource.json.WriterConfig;
 public class NodeJSCfgBuildCompiler extends JSCfgBuildCompiler {
 	@Override
 	public void generateBuildScript(Configuration cfg, Context ctx) {
-		String json = "";
-		String nameKebabCase = cfg.getName().replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase();
-		for (String line : readResource("lib/package.json"))
-			json += line.replace("<NAME>", nameKebabCase);
 		
+		String json = String.join("", readResource("lib/package.json"));
 		JsonObject pkg = Json.parse(json).asObject();
+		
+		String nameKebabCase = cfg.getName().replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase();
+		pkg.set("name", nameKebabCase);
+		
+		pkg.set("description", AnnotatedElementHelper.annotationOrElse(
+				cfg, "nodejs_package_description", nameKebabCase +" configuration generated from ThingML"));
+		
+		pkg.set("version", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_version", "1.0.0"));
+		pkg.set("license", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_license", "Apache-2.0"));
+		pkg.set("repository", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_repository", ""));
+		
+		JsonObject author = pkg.get("author").asObject();
+		author.set("name", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_author_name", ""));
+		author.set("email", AnnotatedElementHelper.annotationOrElse(cfg, "nodejs_package_author_email", ""));
+		
 		JsonValue deps = pkg.get("dependencies");
 		
 		if (AnnotatedElementHelper.hasAnnotation(cfg, "arguments")) {

--- a/compilers/javascript/src/main/resources/javascript/lib/package.json
+++ b/compilers/javascript/src/main/resources/javascript/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "<NAME>",
-  "version": "1.0.0",
-  "description": "<NAME> configuration generated from ThingML",
+  "version": "<VERSION>",
+  "description": "<DESCRIPTION>",
   "main": "main.js",
   "private": true,
   "dependencies": {
@@ -11,12 +11,12 @@
   },
   "scripts": {
   },
-  "repository": "",
+  "repository": "<REPOSITORY>",
   "author": {
-    "name": "John Doe",
-    "email": "John@Doe.com"
+    "name": "<AUTHOR_NAME>",
+    "email": "<AUTHOR_EMAIL>"
   },
-  "license": "Apache-2.0",
+  "license": "<LICENSE>",
   "eslintConfig": {
     "env": {
       "node": true
@@ -29,7 +29,6 @@
     },
     "rules": {
       "no-console": 0,
-      "no-unused-vars": ["error", {"args": "none" }],
       "no-mixed-spaces-and-tabs": 0,
       "no-unreachable": 0,
       "no-extra-semi": 0,


### PR DESCRIPTION
NodeJS packages names are better in kebab-case.

Example :

`SuperStateMachine` ➡ `super-state-machine`

New annotations:

 * `@nodejs_package_description`
 * `@nodejs_package_author_name`
 * `@nodejs_package_author_email`
 * `@nodejs_package_license`
 * `@nodejs_package_version`
 * `@nodejs_package_repository`