### PR TITLE
Fix Javascript String Literals : They can now contain single quotes 😮

### DIFF
--- a/compilers/javascript/src/main/java/org/thingml/compilers/javascript/JSThingActionCompiler.java
+++ b/compilers/javascript/src/main/java/org/thingml/compilers/javascript/JSThingActionCompiler.java
@@ -310,7 +310,7 @@ public class JSThingActionCompiler extends CommonThingActionCompiler {
 
 	@Override
 	public void generate(StringLiteral expression, StringBuilder builder, Context ctx) {
-		builder.append("'" + expression.getStringValue() + "'");
+		builder.append("'" + expression.getStringValue().replaceAll("'", "\\\\'") + "'");
 	}
 
 	@Override


### PR DESCRIPTION
I may comment on the 4 required backslashs in Java every time I see a troll about PHP's ugliness.