### PR TITLE
Fix global warming due to ThingML

### DIFF
--- a/compilers/javascript/src/main/java/org/thingml/compilers/javascript/JSThingApiCompiler.java
+++ b/compilers/javascript/src/main/java/org/thingml/compilers/javascript/JSThingApiCompiler.java
@@ -73,6 +73,7 @@ public class JSThingApiCompiler extends ThingApiCompiler {
                 if(ThingHelper.hasSession(thing))
                 	body.append("this.forks = [];");
                 body.append("this.ready = false;");
+                body.append("this.stopped = true;");
                 if (ThingMLHelpers.allStateMachines(thing).get(0).getExit() != null)
                     ctx.getCompiler().getThingActionCompiler().generate(ThingMLHelpers.allStateMachines(thing).get(0).getExit(), body.stringbuilder("onexit"), ctx);
         	}
@@ -103,9 +104,9 @@ public class JSThingApiCompiler extends ThingApiCompiler {
         			       .section("foreach").lines().indent()
         			       .append("fork._receive(msg);")
         			       .after("});");
-        		body.append("} else {")
+        		body.append("} else if (!this.stopped) {")
         			.section("else").lines().indent()
-        			.append("setTimeout(()=>this._receive(msg),0);")
+        			.append("setTimeout(()=>this._receive(msg),4);")
         			.after("}");
         	}
         } else {


### PR DESCRIPTION
A state machine with a final state has an infinite loop for every new incoming message.
It's because the state machine is stopped, and therefore not ready, so the message is sent again at the next tick.
If the state machine has a final state and uses timers, it will receive quite a lot of messages that will loop forever, using more and more cpu.